### PR TITLE
[docs] Index.md pip library typo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,7 @@ If `pytest-cases` helps you with your research work, don't hesitate to spread th
 ## Installing
 
 ```bash
-> pip install pytest_cases
+> pip install pytest-cases
 ```
 
 Note: Installing pytest-cases has effects on the order of `pytest` tests execution, even if you do not use its features. One positive side effect is that it fixed [pytest#5054](https://github.com/pytest-dev/pytest/issues/5054). But if you see less desirable ordering please [report it](https://github.com/smarie/python-pytest-cases/issues).


### PR DESCRIPTION
`pytest_cases` is not an installable package via pip. I guess it should be `pytest-cases`